### PR TITLE
Add WOLFSSL/include to ngx_feature_path

### DIFF
--- a/nginx-1.10.3-wolfssl.patch
+++ b/nginx-1.10.3-wolfssl.patch
@@ -33,7 +33,7 @@ diff -ur nginx-1.10.3/auto/lib/openssl/conf nginx-1.10.3-wolfssl/auto/lib/openss
 +
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
-+            ngx_feature_path="$WOLFSSL/include/wolfssl"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl -lm $NGX_LIBDL"

--- a/nginx-1.11.10-wolfssl.patch
+++ b/nginx-1.11.10-wolfssl.patch
@@ -14,7 +14,7 @@ diff -ur nginx-1.11.10/auto/lib/openssl/conf nginx-1.11.10-wolfssl/auto/lib/open
 +
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
-+            ngx_feature_path="$WOLFSSL/include/wolfssl"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl -lm $NGX_LIBDL"

--- a/nginx-1.11.13-wolfssl.patch
+++ b/nginx-1.11.13-wolfssl.patch
@@ -14,7 +14,7 @@ diff -ur nginx-1.11.13/auto/lib/openssl/conf nginx-1.11.13-wolfssl/auto/lib/open
 +
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
-+            ngx_feature_path="$WOLFSSL/include/wolfssl"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl -lm $NGX_LIBDL"

--- a/nginx-1.11.7-wolfssl.patch
+++ b/nginx-1.11.7-wolfssl.patch
@@ -33,7 +33,7 @@ diff -ur nginx-1.11.7/auto/lib/openssl/conf nginx-1.11.7-wolfssl/auto/lib/openss
 +
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
-+            ngx_feature_path="$WOLFSSL/include/wolfssl"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl -lm $NGX_LIBDL"

--- a/nginx-1.12.0-wolfssl.patch
+++ b/nginx-1.12.0-wolfssl.patch
@@ -14,7 +14,7 @@ diff -ur nginx-1.12.0/auto/lib/openssl/conf nginx-1.12.0-wolfssl/auto/lib/openss
 +
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
-+            ngx_feature_path="$WOLFSSL/include/wolfssl"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl -lm $NGX_LIBDL"

--- a/nginx-1.12.1-wolfssl.patch
+++ b/nginx-1.12.1-wolfssl.patch
@@ -14,7 +14,7 @@ diff -ur nginx-1.12.1/auto/lib/openssl/conf nginx-1.12.1-wolfssl/auto/lib/openss
 +
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
-+            ngx_feature_path="$WOLFSSL/include/wolfssl"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl -lm $NGX_LIBDL"

--- a/nginx-1.12.2-wolfssl.patch
+++ b/nginx-1.12.2-wolfssl.patch
@@ -14,7 +14,7 @@ diff -ur nginx-1.12.2/auto/lib/openssl/conf nginx-1.12.2-wolfssl/auto/lib/openss
 +
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
-+            ngx_feature_path="$WOLFSSL/include/wolfssl"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl -lm $NGX_LIBDL"

--- a/nginx-1.13.0-wolfssl.patch
+++ b/nginx-1.13.0-wolfssl.patch
@@ -14,7 +14,7 @@ diff -ur nginx-1.13.0/auto/lib/openssl/conf nginx-1.13.0-wolfssl/auto/lib/openss
 +
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
-+            ngx_feature_path="$WOLFSSL/include/wolfssl"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl -lm $NGX_LIBDL"

--- a/nginx-1.13.12-wolfssl.patch
+++ b/nginx-1.13.12-wolfssl.patch
@@ -8,7 +8,7 @@ diff -ur nginx-1.13.12/auto/lib/openssl/conf nginx-1.13.12-wolfssl/auto/lib/open
 +
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
-+            ngx_feature_path="$WOLFSSL/include/wolfssl"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl $NGX_LIBDL"

--- a/nginx-1.13.2-wolfssl.patch
+++ b/nginx-1.13.2-wolfssl.patch
@@ -14,7 +14,7 @@ diff -ur nginx-1.13.2/auto/lib/openssl/conf nginx-1.13.2-wolfssl/auto/lib/openss
 +
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
-+            ngx_feature_path="$WOLFSSL/include/wolfssl"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl -lm $NGX_LIBDL"

--- a/nginx-1.13.8-wolfssl.patch
+++ b/nginx-1.13.8-wolfssl.patch
@@ -14,7 +14,7 @@ diff -ur nginx-1.13.8/auto/lib/openssl/conf nginx-1.13.8-wolfssl/auto/lib/openss
 +
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
-+            ngx_feature_path="$WOLFSSL/include/wolfssl"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl -lm $NGX_LIBDL"

--- a/nginx-1.14.0-wolfssl.patch
+++ b/nginx-1.14.0-wolfssl.patch
@@ -8,7 +8,7 @@ diff -ur nginx-1.14.0/auto/lib/openssl/conf nginx-1.14.0-wolfssl/auto/lib/openss
 +
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
-+            ngx_feature_path="$WOLFSSL/include/wolfssl"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl $NGX_LIBDL"


### PR DESCRIPTION
Added $WOLFSSL/include for running Nginx tests. This fixes the "Could not find wolfSSL" error when configuring Nginx with wolfSSL on Jenkins. 