### PR TITLE
Add missing includes

### DIFF
--- a/nginx-1.21.4-wolfssl.patch
+++ b/nginx-1.21.4-wolfssl.patch
@@ -1,8 +1,8 @@
 diff --git a/auto/lib/openssl/conf b/auto/lib/openssl/conf
-index 4fb52df7..4fe4b4a7 100644
+index 4fb52df..5c39915 100644
 --- a/auto/lib/openssl/conf
 +++ b/auto/lib/openssl/conf
-@@ -62,8 +62,33 @@ else
+@@ -62,8 +62,35 @@ else
          ngx_feature_path=
          ngx_feature_libs="-lssl -lcrypto $NGX_LIBDL $NGX_LIBPTHREAD"
          ngx_feature_test="SSL_CTX_set_options(NULL, 0)"
@@ -10,6 +10,8 @@ index 4fb52df7..4fe4b4a7 100644
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
 +            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
++            ngx_feature_incs="#include <wolfssl/options.h>
++                              #include <openssl/ssl.h>"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl $NGX_LIBDL"
@@ -22,7 +24,7 @@ index 4fb52df7..4fe4b4a7 100644
 +        fi
 +
          . auto/feature
- 
+
 +        if [ $WOLFSSL != NONE -a $ngx_found = no ]; then
 +cat << END
 +
@@ -34,44 +36,44 @@ index 4fb52df7..4fe4b4a7 100644
 +        fi
 +
          if [ $ngx_found = no ]; then
- 
+
              # FreeBSD port
 diff --git a/auto/options b/auto/options
-index 80be906e..8767aa33 100644
+index 80be906..8767aa3 100644
 --- a/auto/options
 +++ b/auto/options
 @@ -149,6 +149,7 @@ PCRE_JIT=NO
- 
+
  USE_OPENSSL=NO
  OPENSSL=NONE
 +WOLFSSL=NONE
- 
+
  USE_ZLIB=NO
  ZLIB=NONE
 @@ -358,6 +359,7 @@ use the \"--with-mail_ssl_module\" option instead"
          --with-pcre-opt=*)               PCRE_OPT="$value"          ;;
          --with-pcre-jit)                 PCRE_JIT=YES               ;;
- 
+
 +        --with-wolfssl=*)                WOLFSSL="$value"           ;;
          --with-openssl=*)                OPENSSL="$value"           ;;
          --with-openssl-opt=*)            OPENSSL_OPT="$value"       ;;
- 
+
 @@ -583,6 +585,7 @@ cat << END
    --with-libatomic                   force libatomic_ops library usage
    --with-libatomic=DIR               set path to libatomic_ops library sources
- 
+
 +  --with-wolfssl=DIR                 set path to wolfSSL headers and library
    --with-openssl=DIR                 set path to OpenSSL library sources
    --with-openssl-opt=OPTIONS         set additional build options for OpenSSL
- 
+
 diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
-index 84afecd0..fe7e328e 100644
+index 84afecd..fe7e328 100644
 --- a/src/event/ngx_event_openssl.c
 +++ b/src/event/ngx_event_openssl.c
 @@ -353,6 +353,8 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
      }
  #endif
- 
+
 +#ifndef WOLFSSL_NGINX
 +    /* These override the options set above. No need to call this. */
  #ifdef SSL_CTX_set_min_proto_version
@@ -82,13 +84,13 @@ index 84afecd0..fe7e328e 100644
      SSL_CTX_set_max_proto_version(ssl->ctx, TLS1_3_VERSION);
  #endif
 +#endif
- 
+
  #ifdef SSL_OP_NO_COMPRESSION
      SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_COMPRESSION);
 @@ -391,6 +394,12 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
- 
+
      SSL_CTX_set_info_callback(ssl->ctx, ngx_ssl_info_callback);
- 
+
 +#ifdef WOLFSSL_NGINX
 +    SSL_CTX_set_verify(ssl->ctx, SSL_VERIFY_NONE, NULL);
 +    wolfSSL_CTX_allow_anon_cipher(ssl->ctx);
@@ -97,11 +99,11 @@ index 84afecd0..fe7e328e 100644
 +
      return NGX_OK;
  }
- 
+
 @@ -864,6 +873,14 @@ ngx_ssl_ciphers(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *ciphers,
  }
- 
- 
+
+
 +ngx_int_t
 +ngx_ssl_set_verify_on(ngx_conf_t *cf, ngx_ssl_t *ssl)
 +{
@@ -116,11 +118,11 @@ index 84afecd0..fe7e328e 100644
 @@ -1407,7 +1424,8 @@ ngx_ssl_ecdh_curve(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *name)
       * maximum interoperability.
       */
- 
+
 -#if (defined SSL_CTX_set1_curves_list || defined SSL_CTRL_SET_CURVES_LIST)
 +#if (defined SSL_CTX_set1_curves_list || defined SSL_CTRL_SET_CURVES_LIST) || \
 +    defined(WOLFSSL_NGINX)
- 
+
      /*
       * OpenSSL 1.0.2+ allows configuring a curve list instead of a single
 @@ -1599,10 +1617,26 @@ static int
@@ -130,9 +132,9 @@ index 84afecd0..fe7e328e 100644
 +#ifdef WOLFSSL_NGINX
 +    int len;
 +#endif
- 
+
      c = ngx_ssl_get_connection(ssl_conn);
- 
+
      if (c->ssl->save_session) {
 +#ifdef WOLFSSL_NGINX
 +        len = i2d_SSL_SESSION(sess, NULL);
@@ -148,7 +150,7 @@ index 84afecd0..fe7e328e 100644
 +#endif
 +
          c->ssl->session = sess;
- 
+
          c->ssl->save_session(c);
 @@ -1674,7 +1708,9 @@ ngx_ssl_get_session(ngx_connection_t *c)
  {
@@ -163,7 +165,7 @@ index 84afecd0..fe7e328e 100644
 @@ -4357,7 +4393,8 @@ ngx_ssl_session_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
              return -1;
          }
- 
+
 -#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 +#if OPENSSL_VERSION_NUMBER >= 0x10000000L && \
 +    (!defined(WOLFSSL_NGINX) || !defined(HAVE_FIPS))
@@ -173,7 +175,7 @@ index 84afecd0..fe7e328e 100644
 @@ -4400,7 +4437,8 @@ ngx_ssl_session_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
              size = 32;
          }
- 
+
 -#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 +#if OPENSSL_VERSION_NUMBER >= 0x10000000L && \
 +    (!defined(WOLFSSL_NGINX) || !defined(HAVE_FIPS))
@@ -181,13 +183,13 @@ index 84afecd0..fe7e328e 100644
              ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
              return -1;
 diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
-index 4afdfad4..053999a8 100644
+index 4afdfad..053999a 100644
 --- a/src/event/ngx_event_openssl.h
 +++ b/src/event/ngx_event_openssl.h
 @@ -14,6 +14,10 @@
- 
+
  #define OPENSSL_SUPPRESS_DEPRECATED
- 
+
 +#ifdef WOLFSSL_NGINX
 +#include <wolfssl/options.h>
 +#include <openssl/pem.h>
@@ -197,15 +199,15 @@ index 4afdfad4..053999a8 100644
  #include <openssl/bn.h>
 @@ -60,7 +64,7 @@
  #define ngx_ssl_conn_t          SSL
- 
- 
+
+
 -#if (OPENSSL_VERSION_NUMBER < 0x10002000L)
 +#if (OPENSSL_VERSION_NUMBER < 0x10002000L) && !defined(WOLFSSL_NGINX)
  #define SSL_is_server(s)        (s)->server
  #endif
- 
+
 @@ -191,6 +195,7 @@ ngx_int_t ngx_ssl_connection_certificate(ngx_connection_t *c, ngx_pool_t *pool,
- 
+
  ngx_int_t ngx_ssl_ciphers(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *ciphers,
      ngx_uint_t prefer_server_ciphers);
 +ngx_int_t ngx_ssl_set_verify_on(ngx_conf_t *cf, ngx_ssl_t *ssl);
@@ -213,7 +215,7 @@ index 4afdfad4..053999a8 100644
      ngx_str_t *cert, ngx_int_t depth);
  ngx_int_t ngx_ssl_trusted_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl,
 diff --git a/src/event/ngx_event_openssl_stapling.c b/src/event/ngx_event_openssl_stapling.c
-index e3fa8c4e..fb8ba0a7 100644
+index e3fa8c4..fb8ba0a 100644
 --- a/src/event/ngx_event_openssl_stapling.c
 +++ b/src/event/ngx_event_openssl_stapling.c
 @@ -379,7 +379,9 @@ ngx_ssl_stapling_issuer(ngx_conf_t *cf, ngx_ssl_t *ssl,
@@ -228,7 +230,7 @@ index e3fa8c4e..fb8ba0a7 100644
  #else
              CRYPTO_add(&issuer->references, 1, CRYPTO_LOCK_X509);
 diff --git a/src/http/modules/ngx_http_proxy_module.c b/src/http/modules/ngx_http_proxy_module.c
-index 7c4061c0..c541b136 100644
+index 7c4061c..c541b13 100644
 --- a/src/http/modules/ngx_http_proxy_module.c
 +++ b/src/http/modules/ngx_http_proxy_module.c
 @@ -4988,7 +4988,9 @@ ngx_http_proxy_set_ssl(ngx_conf_t *cf, ngx_http_proxy_loc_conf_t *plcf)
@@ -243,50 +245,50 @@ index 7c4061c0..c541b136 100644
                                          &plcf->ssl_trusted_certificate,
                                          plcf->ssl_verify_depth)
 diff --git a/src/http/modules/ngx_http_ssl_module.c b/src/http/modules/ngx_http_ssl_module.c
-index c633f346..2a5c420e 100644
+index c633f34..2a5c420 100644
 --- a/src/http/modules/ngx_http_ssl_module.c
 +++ b/src/http/modules/ngx_http_ssl_module.c
 @@ -14,7 +14,11 @@ typedef ngx_int_t (*ngx_ssl_variable_handler_pt)(ngx_connection_t *c,
      ngx_pool_t *pool, ngx_str_t *s);
- 
- 
+
+
 +#ifndef WOLFSSL_NGINX
  #define NGX_DEFAULT_CIPHERS     "HIGH:!aNULL:!MD5"
 +#else
 +#define NGX_DEFAULT_CIPHERS     "ALL"
 +#endif
  #define NGX_DEFAULT_ECDH_CURVE  "auto"
- 
+
  #define NGX_HTTP_ALPN_PROTOS    "\x08http/1.1\x08http/1.0\x08http/0.9"
 @@ -845,8 +849,10 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
          return NGX_CONF_ERROR;
      }
- 
+
 +#ifndef WOLFSSL_NGINX
      ngx_conf_merge_value(conf->builtin_session_cache,
                           prev->builtin_session_cache, NGX_SSL_NONE_SCACHE);
 +#endif
- 
+
      if (conf->shm_zone == NULL) {
          conf->shm_zone = prev->shm_zone;
 diff --git a/src/mail/ngx_mail_ssl_module.c b/src/mail/ngx_mail_ssl_module.c
-index 2a1043e6..8012fcce 100644
+index 2a1043e..8012fcc 100644
 --- a/src/mail/ngx_mail_ssl_module.c
 +++ b/src/mail/ngx_mail_ssl_module.c
 @@ -10,7 +10,11 @@
  #include <ngx_mail.h>
- 
- 
+
+
 +#ifndef WOLFSSL_NGINX
  #define NGX_DEFAULT_CIPHERS     "HIGH:!aNULL:!MD5"
 +#else
 +#define NGX_DEFAULT_CIPHERS     "ALL"
 +#endif
  #define NGX_DEFAULT_ECDH_CURVE  "auto"
- 
- 
+
+
 diff --git a/src/stream/ngx_stream_proxy_module.c b/src/stream/ngx_stream_proxy_module.c
-index 934e7d8f..c4c0e2e2 100644
+index 934e7d8..c4c0e2e 100644
 --- a/src/stream/ngx_stream_proxy_module.c
 +++ b/src/stream/ngx_stream_proxy_module.c
 @@ -2262,7 +2262,9 @@ ngx_stream_proxy_set_ssl(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *pscf)
@@ -301,21 +303,20 @@ index 934e7d8f..c4c0e2e2 100644
                                          &pscf->ssl_trusted_certificate,
                                          pscf->ssl_verify_depth)
 diff --git a/src/stream/ngx_stream_ssl_module.c b/src/stream/ngx_stream_ssl_module.c
-index 530fe8b3..77f59d04 100644
+index 530fe8b..77f59d0 100644
 --- a/src/stream/ngx_stream_ssl_module.c
 +++ b/src/stream/ngx_stream_ssl_module.c
 @@ -14,7 +14,11 @@ typedef ngx_int_t (*ngx_ssl_variable_handler_pt)(ngx_connection_t *c,
      ngx_pool_t *pool, ngx_str_t *s);
- 
- 
+
+
 +#ifndef WOLFSSL_NGINX
  #define NGX_DEFAULT_CIPHERS     "HIGH:!aNULL:!MD5"
 +#else
 +#define NGX_DEFAULT_CIPHERS     "ALL"
 +#endif
  #define NGX_DEFAULT_ECDH_CURVE  "auto"
- 
- 
--- 
-2.25.1
 
+
+--
+2.34.1


### PR DESCRIPTION
@kareem-wolfssl I updated the patch to fix the problem with the configuration of Nginx with WolfSSL (./configure: error: Could not find wolfSSL at /usr/local/include/wolfssl), as discussed by mail.

I tested it (on Nginx 1.21.4: apply the path, configure and compile), it works fine