### PR TITLE
Add missing wolfSSL includes and alert history logging.

### DIFF
--- a/nginx-1.21.4-wolfssl.patch
+++ b/nginx-1.21.4-wolfssl.patch
@@ -2,7 +2,7 @@ diff --git a/auto/lib/openssl/conf b/auto/lib/openssl/conf
 index 4fb52df7..4fe4b4a7 100644
 --- a/auto/lib/openssl/conf
 +++ b/auto/lib/openssl/conf
-@@ -62,8 +62,33 @@ else
+@@ -62,8 +62,42 @@
          ngx_feature_path=
          ngx_feature_libs="-lssl -lcrypto $NGX_LIBDL $NGX_LIBPTHREAD"
          ngx_feature_test="SSL_CTX_set_options(NULL, 0)"
@@ -221,7 +221,7 @@ diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
 index 4afdfad4..053999a8 100644
 --- a/src/event/ngx_event_openssl.h
 +++ b/src/event/ngx_event_openssl.h
-@@ -14,6 +14,10 @@
+@@ -14,6 +14,17 @@
  
  #define OPENSSL_SUPPRESS_DEPRECATED
  

--- a/nginx-1.21.4-wolfssl.patch
+++ b/nginx-1.21.4-wolfssl.patch
@@ -169,6 +169,34 @@ index 84afecd0..fe7e328e 100644
          return c->ssl->session;
      }
  #endif
+@@ -3306,6 +3341,27 @@
+     int         n;
+     ngx_uint_t  level;
+
++#ifdef WOLFSSL_NGINX
++    WOLFSSL_ALERT_HISTORY h;
++
++    if (c && c->ssl && c->ssl->connection) {
++        wolfSSL_get_alert_history(c->ssl->connection, &h);
++        if (h.last_rx.level == alert_warning || h.last_rx.level == alert_fatal ||
++            h.last_tx.level == alert_warning || h.last_tx.level == alert_fatal) {
++            const char *rx_code, *rx_lvl, *tx_code, *tx_lvl;
++            rx_lvl = ((h.last_rx.level == alert_fatal) ? "fatal" : ((h.last_rx.level == alert_warning) ? "warning" : "none"));
++            tx_lvl = ((h.last_tx.level == alert_fatal) ? "fatal" : ((h.last_tx.level == alert_warning) ? "warning" : "none"));
++            rx_code = wolfSSL_alert_desc_string_long(h.last_rx.code);
++            tx_code = wolfSSL_alert_desc_string_long(h.last_tx.code);
++            if (!rx_code) rx_code = "none";
++            if (!tx_code) tx_code = "none";
++            ngx_log_error(NGX_LOG_CRIT, c->log, 0,
++                        "%s (RX alert: level=%s,code=%s, TX alert: level=%s,code=%s)",
++                        text, rx_lvl, rx_code, tx_lvl, tx_code);
++        }
++    }
++#endif
++
+     level = NGX_LOG_CRIT;
+
+     if (sslerr == SSL_ERROR_SYSCALL) {
 @@ -4357,7 +4393,8 @@ ngx_ssl_session_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
              return -1;
          }
@@ -198,7 +226,14 @@ index 4afdfad4..053999a8 100644
  #define OPENSSL_SUPPRESS_DEPRECATED
  
 +#ifdef WOLFSSL_NGINX
-+#include <wolfssl/options.h>
++#ifdef HAVE_CONFIG_H
++    #include <config.h>
++#endif
++
++#ifndef WOLFSSL_USER_SETTINGS
++    #include <wolfssl/options.h>
++#endif
++#include <wolfssl/wolfcrypt/settings.h>
 +#include <openssl/pem.h>
 +#endif
  #include <openssl/ssl.h>

--- a/nginx-1.21.4-wolfssl.patch
+++ b/nginx-1.21.4-wolfssl.patch
@@ -10,6 +10,15 @@ index 4fb52df7..4fe4b4a7 100644
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
 +            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
++            ngx_feature_incs="#ifdef HAVE_CONFIG_H
++                #include <config.h>
++            #endif
++
++            #ifndef WOLFSSL_USER_SETTINGS
++                #include <wolfssl/options.h>
++            #endif
++            #include <wolfssl/wolfcrypt/settings.h>
++            #include <openssl/ssl.h>"
 +
 +            if [ $NGX_RPATH = YES ]; then
 +                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl $NGX_LIBDL"


### PR DESCRIPTION
Without the relevant settings header included, nginx's test program compilation will fail:

```
> ----------------------------------------
> checking for wolfSSL library in /usr/local
>
> In file included from /usr/local/include/wolfssl/ssl.h:33,
> from /usr/local/include/wolfssl/openssl/ssl.h:35,
> from objs/autotest.c:4:
> /usr/local/include/wolfssl/wolfcrypt/settings.h:2369:14: warning: #warning "For timing resistance / side-channel attack prevention consider using harden options" [-Wcpp]
> 2369 | #warning "For timing resistance / side-channel attack prevention consider using harden options"
> | ^~~~~~~
> objs/autotest.c: In function 'main':
> objs/autotest.c:7:5: warning: implicit declaration of function 'SSL_CTX_set_options'; did you mean 'wolfSSL_CTX_set_options'? [-Wimplicit-function-declaration]
> 7 | SSL_CTX_set_options(NULL, 0);
> | ^~~~~~~~~~~~~~~~~~~
> | wolfSSL_CTX_set_options
> /usr/bin/ld: /tmp/cc2WacIU.o: in function `main':
> autotest.c:(.text+0x18): undefined reference to `SSL_CTX_set_options'
> collect2: error: ld returned 1 exit status
> ----------
>
> #include <sys/types.h>
> #include <unistd.h>
> #include <openssl/ssl.h>
>
> int main(void) {
> SSL_CTX_set_options(NULL, 0);
> return 0;
> }
>
> ----------
> cc -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -I /usr/local/include/wolfssl -I /usr/local/include -o objs/autotest objs/autotest.c -L/usr/local/lib -lwolfssl
> ----------
```