### PR TITLE
Add patches for nginx 1.25.0 and corresponding nginx-tests patch

### DIFF
--- a/nginx-1.25.0-wolfssl-debug.patch
+++ b/nginx-1.25.0-wolfssl-debug.patch
@@ -1,0 +1,31 @@
+diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+index 694896d..4264650 100644
+--- a/src/event/ngx_event_openssl.c
++++ b/src/event/ngx_event_openssl.c
+@@ -136,6 +136,13 @@ int  ngx_ssl_next_certificate_index;
+ int  ngx_ssl_certificate_name_index;
+ int  ngx_ssl_stapling_index;
+ 
++#ifdef WOLFSSL_NGINX
++void wolfSSL_Log(const int logLevel, const char *const logMessage)
++{
++    (void)logLevel;
++    ngx_log_stderr(0, "wolfSSL: %s", logMessage);
++}
++#endif
+ 
+ ngx_int_t
+ ngx_ssl_init(ngx_log_t *log)
+@@ -165,6 +172,12 @@ ngx_ssl_init(ngx_log_t *log)
+ 
+ #endif
+ 
++#ifdef WOLFSSL_NGINX
++    /* Turn on internal wolfssl debugging to stderr */
++    wolfSSL_SetLoggingCb(wolfSSL_Log);
++    wolfSSL_Debugging_ON();
++#endif
++
+ #ifndef SSL_OP_NO_COMPRESSION
+     {
+     /*

--- a/nginx-1.25.0-wolfssl.patch
+++ b/nginx-1.25.0-wolfssl.patch
@@ -74,7 +74,7 @@ index 552ef83..96f0d8e 100644
    --with-openssl-opt=OPTIONS         set additional build options for OpenSSL
  
 diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
-index c38aa27..694896d 100644
+index c38aa27..3a2f8fb 100644
 --- a/src/event/ngx_event_openssl.c
 +++ b/src/event/ngx_event_openssl.c
 @@ -351,6 +351,8 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
@@ -94,7 +94,52 @@ index c38aa27..694896d 100644
  
  #ifdef SSL_OP_NO_COMPRESSION
      SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_COMPRESSION);
-@@ -1455,7 +1458,8 @@ ngx_ssl_ecdh_curve(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *name)
+@@ -557,6 +560,12 @@ ngx_ssl_connection_certificate(ngx_connection_t *c, ngx_pool_t *pool,
+         return NGX_ERROR;
+     }
+ 
++#ifdef WOLFSSL_NGINX
++    /* Remove current chain */
++    if (sk_X509_NAME_num(chain) > 0)
++        wolfSSL_UnloadCertsKeys(c->ssl->connection);
++#endif
++
+     if (SSL_use_certificate(c->ssl->connection, x509) == 0) {
+         ngx_ssl_error(NGX_LOG_ERR, c->log, 0,
+                       "SSL_use_certificate(\"%s\") failed", cert->data);
+@@ -568,7 +577,9 @@ ngx_ssl_connection_certificate(ngx_connection_t *c, ngx_pool_t *pool,
+     X509_free(x509);
+ 
+ #ifdef SSL_set0_chain
+-
++#ifdef WOLFSSL_NGINX
++#error If SSL_set0_chain is defined then reset this function
++#endif
+     /*
+      * SSL_set0_chain() is only available in OpenSSL 1.0.2+,
+      * but this function is only called via certificate callback,
+@@ -581,7 +592,19 @@ ngx_ssl_connection_certificate(ngx_connection_t *c, ngx_pool_t *pool,
+         sk_X509_pop_free(chain, X509_free);
+         return NGX_ERROR;
+     }
+-
++#endif
++#ifdef WOLFSSL_NGINX
++    {
++        int i;
++        for (i = sk_X509_num(chain) - 1; i > 0; i--) {
++            if (wolfSSL_add0_chain_cert(c->ssl->connection,
++                    sk_X509_value(chain, i)) == 0) {
++                sk_X509_pop_free(chain, X509_free);
++                return NGX_ERROR;
++            }
++        }
++        sk_X509_pop_free(chain, X509_free);
++    }
+ #endif
+ 
+     pkey = ngx_ssl_load_certificate_key(pool, &err, key, passwords);
+@@ -1455,7 +1478,8 @@ ngx_ssl_ecdh_curve(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *name)
       * maximum interoperability.
       */
  
@@ -104,7 +149,7 @@ index c38aa27..694896d 100644
  
      /*
       * OpenSSL 1.0.2+ allows configuring a curve list instead of a single
-@@ -3358,6 +3362,27 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
+@@ -3358,6 +3382,27 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
      int         n;
      ngx_uint_t  level;
  
@@ -132,7 +177,7 @@ index c38aa27..694896d 100644
      level = NGX_LOG_CRIT;
  
      if (sslerr == SSL_ERROR_SYSCALL) {
-@@ -4577,7 +4602,8 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
+@@ -4577,7 +4622,8 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
              return -1;
          }
  
@@ -142,7 +187,7 @@ index c38aa27..694896d 100644
          if (HMAC_Init_ex(hctx, key[0].hmac_key, size, digest, NULL) != 1) {
              ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
              return -1;
-@@ -4620,7 +4646,8 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
+@@ -4620,7 +4666,8 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
              size = 32;
          }
  
@@ -152,7 +197,7 @@ index c38aa27..694896d 100644
          if (HMAC_Init_ex(hctx, key[i].hmac_key, size, digest, NULL) != 1) {
              ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
              return -1;
-@@ -5127,6 +5154,14 @@ ngx_ssl_get_curve(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+@@ -5127,6 +5174,14 @@ ngx_ssl_get_curve(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
  
  #endif
  

--- a/nginx-1.25.0-wolfssl.patch
+++ b/nginx-1.25.0-wolfssl.patch
@@ -1,8 +1,8 @@
 diff --git a/auto/lib/openssl/conf b/auto/lib/openssl/conf
-index cfa74cf..77c8572 100644
+index cfa74cf..bb57e33 100644
 --- a/auto/lib/openssl/conf
 +++ b/auto/lib/openssl/conf
-@@ -64,8 +64,42 @@ else
+@@ -64,8 +64,39 @@ else
          ngx_feature_path=
          ngx_feature_libs="-lssl -lcrypto $NGX_LIBDL $NGX_LIBPTHREAD"
          ngx_feature_test="SSL_CTX_set_options(NULL, 0)"
@@ -10,10 +10,7 @@ index cfa74cf..77c8572 100644
 +        if [ $WOLFSSL != NONE ]; then
 +            ngx_feature="wolfSSL library in $WOLFSSL"
 +            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
-+            ngx_feature_incs="#ifdef HAVE_CONFIG_H
-+                #include <config.h>
-+            #endif
-+
++            ngx_feature_incs="
 +            #ifndef WOLFSSL_USER_SETTINGS
 +                #include <wolfssl/options.h>
 +            #endif
@@ -74,7 +71,7 @@ index 552ef83..96f0d8e 100644
    --with-openssl-opt=OPTIONS         set additional build options for OpenSSL
  
 diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
-index c38aa27..3a2f8fb 100644
+index c38aa27..e3c7755 100644
 --- a/src/event/ngx_event_openssl.c
 +++ b/src/event/ngx_event_openssl.c
 @@ -351,6 +351,8 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
@@ -139,17 +136,7 @@ index c38aa27..3a2f8fb 100644
  #endif
  
      pkey = ngx_ssl_load_certificate_key(pool, &err, key, passwords);
-@@ -1455,7 +1478,8 @@ ngx_ssl_ecdh_curve(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *name)
-      * maximum interoperability.
-      */
- 
--#if (defined SSL_CTX_set1_curves_list || defined SSL_CTRL_SET_CURVES_LIST)
-+#if (defined SSL_CTX_set1_curves_list || defined SSL_CTRL_SET_CURVES_LIST) || \
-+    defined(WOLFSSL_NGINX)
- 
-     /*
-      * OpenSSL 1.0.2+ allows configuring a curve list instead of a single
-@@ -3358,6 +3382,27 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
+@@ -3358,6 +3381,27 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
      int         n;
      ngx_uint_t  level;
  
@@ -177,7 +164,7 @@ index c38aa27..3a2f8fb 100644
      level = NGX_LOG_CRIT;
  
      if (sslerr == SSL_ERROR_SYSCALL) {
-@@ -4577,7 +4622,8 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
+@@ -4577,7 +4621,8 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
              return -1;
          }
  
@@ -187,7 +174,7 @@ index c38aa27..3a2f8fb 100644
          if (HMAC_Init_ex(hctx, key[0].hmac_key, size, digest, NULL) != 1) {
              ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
              return -1;
-@@ -4620,7 +4666,8 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
+@@ -4620,7 +4665,8 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
              size = 32;
          }
  
@@ -197,7 +184,7 @@ index c38aa27..3a2f8fb 100644
          if (HMAC_Init_ex(hctx, key[i].hmac_key, size, digest, NULL) != 1) {
              ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
              return -1;
-@@ -5127,6 +5174,14 @@ ngx_ssl_get_curve(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+@@ -5127,6 +5173,14 @@ ngx_ssl_get_curve(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
  
  #endif
  

--- a/nginx-1.25.0-wolfssl.patch
+++ b/nginx-1.25.0-wolfssl.patch
@@ -1,0 +1,239 @@
+diff --git a/auto/lib/openssl/conf b/auto/lib/openssl/conf
+index cfa74cf..77c8572 100644
+--- a/auto/lib/openssl/conf
++++ b/auto/lib/openssl/conf
+@@ -64,8 +64,42 @@ else
+         ngx_feature_path=
+         ngx_feature_libs="-lssl -lcrypto $NGX_LIBDL $NGX_LIBPTHREAD"
+         ngx_feature_test="SSL_CTX_set_options(NULL, 0)"
++
++        if [ $WOLFSSL != NONE ]; then
++            ngx_feature="wolfSSL library in $WOLFSSL"
++            ngx_feature_path="$WOLFSSL/include/wolfssl $WOLFSSL/include"
++            ngx_feature_incs="#ifdef HAVE_CONFIG_H
++                #include <config.h>
++            #endif
++
++            #ifndef WOLFSSL_USER_SETTINGS
++                #include <wolfssl/options.h>
++            #endif
++            #include <wolfssl/wolfcrypt/settings.h>
++            #include <openssl/ssl.h>"
++
++            if [ $NGX_RPATH = YES ]; then
++                ngx_feature_libs="-R$WOLFSSL/lib -L$WOLFSSL/lib -lwolfssl $NGX_LIBDL"
++            else
++                ngx_feature_libs="-L$WOLFSSL/lib -lwolfssl $NGX_LIBDL"
++            fi
++
++            CORE_INCS="$CORE_INCS $WOLFSSL/include/wolfssl"
++            CFLAGS="$CFLAGS -DWOLFSSL_NGINX"
++        fi
++
+         . auto/feature
+ 
++        if [ $WOLFSSL != NONE -a $ngx_found = no ]; then
++cat << END
++
++$0: error: Could not find wolfSSL at $WOLFSSL/include/wolfssl.
++SSL modules require the wolfSSL library.
++
++END
++            exit 1
++        fi
++
+         if [ $ngx_found = no ]; then
+ 
+             # FreeBSD port
+diff --git a/auto/options b/auto/options
+index 552ef83..96f0d8e 100644
+--- a/auto/options
++++ b/auto/options
+@@ -154,6 +154,7 @@ PCRE2=YES
+ USE_OPENSSL=NO
+ USE_OPENSSL_QUIC=NO
+ OPENSSL=NONE
++WOLFSSL=NONE
+ 
+ USE_ZLIB=NO
+ ZLIB=NONE
+@@ -369,6 +370,7 @@ use the \"--with-mail_ssl_module\" option instead"
+         --with-pcre-jit)                 PCRE_JIT=YES               ;;
+         --without-pcre2)                 PCRE2=DISABLED             ;;
+ 
++        --with-wolfssl=*)                WOLFSSL="$value"           ;;
+         --with-openssl=*)                OPENSSL="$value"           ;;
+         --with-openssl-opt=*)            OPENSSL_OPT="$value"       ;;
+ 
+@@ -598,6 +600,7 @@ cat << END
+   --with-libatomic                   force libatomic_ops library usage
+   --with-libatomic=DIR               set path to libatomic_ops library sources
+ 
++  --with-wolfssl=DIR                 set path to wolfSSL headers and library
+   --with-openssl=DIR                 set path to OpenSSL library sources
+   --with-openssl-opt=OPTIONS         set additional build options for OpenSSL
+ 
+diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+index c38aa27..694896d 100644
+--- a/src/event/ngx_event_openssl.c
++++ b/src/event/ngx_event_openssl.c
+@@ -351,6 +351,8 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
+     }
+ #endif
+ 
++#ifndef WOLFSSL_NGINX
++    /* These override the options set above. No need to call this. */
+ #ifdef SSL_CTX_set_min_proto_version
+     SSL_CTX_set_min_proto_version(ssl->ctx, 0);
+     SSL_CTX_set_max_proto_version(ssl->ctx, TLS1_2_VERSION);
+@@ -360,6 +362,7 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
+     SSL_CTX_set_min_proto_version(ssl->ctx, 0);
+     SSL_CTX_set_max_proto_version(ssl->ctx, TLS1_3_VERSION);
+ #endif
++#endif
+ 
+ #ifdef SSL_OP_NO_COMPRESSION
+     SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_COMPRESSION);
+@@ -1455,7 +1458,8 @@ ngx_ssl_ecdh_curve(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *name)
+      * maximum interoperability.
+      */
+ 
+-#if (defined SSL_CTX_set1_curves_list || defined SSL_CTRL_SET_CURVES_LIST)
++#if (defined SSL_CTX_set1_curves_list || defined SSL_CTRL_SET_CURVES_LIST) || \
++    defined(WOLFSSL_NGINX)
+ 
+     /*
+      * OpenSSL 1.0.2+ allows configuring a curve list instead of a single
+@@ -3358,6 +3362,27 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
+     int         n;
+     ngx_uint_t  level;
+ 
++#ifdef WOLFSSL_NGINX
++    WOLFSSL_ALERT_HISTORY h;
++
++    if (c && c->ssl && c->ssl->connection) {
++        wolfSSL_get_alert_history(c->ssl->connection, &h);
++        if (h.last_rx.level == alert_warning || h.last_rx.level == alert_fatal ||
++            h.last_tx.level == alert_warning || h.last_tx.level == alert_fatal) {
++            const char *rx_code, *rx_lvl, *tx_code, *tx_lvl;
++            rx_lvl = ((h.last_rx.level == alert_fatal) ? "fatal" : ((h.last_rx.level == alert_warning) ? "warning" : "none"));
++            tx_lvl = ((h.last_tx.level == alert_fatal) ? "fatal" : ((h.last_tx.level == alert_warning) ? "warning" : "none"));
++            rx_code = wolfSSL_alert_desc_string_long(h.last_rx.code);
++            tx_code = wolfSSL_alert_desc_string_long(h.last_tx.code);
++            if (!rx_code) rx_code = "none";
++            if (!tx_code) tx_code = "none";
++            ngx_log_error(NGX_LOG_CRIT, c->log, 0,
++                        "%s (RX alert: level=%s,code=%s, TX alert: level=%s,code=%s)",
++                        text, rx_lvl, rx_code, tx_lvl, tx_code);
++        }
++    }
++#endif
++
+     level = NGX_LOG_CRIT;
+ 
+     if (sslerr == SSL_ERROR_SYSCALL) {
+@@ -4577,7 +4602,8 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
+             return -1;
+         }
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
++#if OPENSSL_VERSION_NUMBER >= 0x10000000L && \
++    (!defined(WOLFSSL_NGINX) || !defined(HAVE_FIPS))
+         if (HMAC_Init_ex(hctx, key[0].hmac_key, size, digest, NULL) != 1) {
+             ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
+             return -1;
+@@ -4620,7 +4646,8 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
+             size = 32;
+         }
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
++#if OPENSSL_VERSION_NUMBER >= 0x10000000L && \
++    (!defined(WOLFSSL_NGINX) || !defined(HAVE_FIPS))
+         if (HMAC_Init_ex(hctx, key[i].hmac_key, size, digest, NULL) != 1) {
+             ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
+             return -1;
+@@ -5127,6 +5154,14 @@ ngx_ssl_get_curve(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+ 
+ #endif
+ 
++#ifdef WOLFSSL_NGINX
++    s->data = (u_char*)wolfSSL_get_curve_name(c->ssl->connection);
++    if (s->data != NULL) {
++        s->len = ngx_strlen(s->data);
++        return NGX_OK;
++    }
++#endif
++
+     s->len = 0;
+     return NGX_OK;
+ }
+diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
+index c062f91..5a55f08 100644
+--- a/src/event/ngx_event_openssl.h
++++ b/src/event/ngx_event_openssl.h
+@@ -14,6 +14,17 @@
+ 
+ #define OPENSSL_SUPPRESS_DEPRECATED
+ 
++#ifdef WOLFSSL_NGINX
++#ifdef HAVE_CONFIG_H
++    #include <config.h>
++#endif
++
++#ifndef WOLFSSL_USER_SETTINGS
++    #include <wolfssl/options.h>
++#endif
++#include <wolfssl/wolfcrypt/settings.h>
++#include <openssl/pem.h>
++#endif
+ #include <openssl/ssl.h>
+ #include <openssl/err.h>
+ #include <openssl/bn.h>
+diff --git a/src/http/modules/ngx_http_ssl_module.c b/src/http/modules/ngx_http_ssl_module.c
+index d2ca475..516b95c 100644
+--- a/src/http/modules/ngx_http_ssl_module.c
++++ b/src/http/modules/ngx_http_ssl_module.c
+@@ -18,7 +18,11 @@ typedef ngx_int_t (*ngx_ssl_variable_handler_pt)(ngx_connection_t *c,
+     ngx_pool_t *pool, ngx_str_t *s);
+ 
+ 
++#ifndef WOLFSSL_NGINX
+ #define NGX_DEFAULT_CIPHERS     "HIGH:!aNULL:!MD5"
++#else
++#define NGX_DEFAULT_CIPHERS     "ALL"
++#endif
+ #define NGX_DEFAULT_ECDH_CURVE  "auto"
+ 
+ #define NGX_HTTP_ALPN_PROTOS    "\x08http/1.1\x08http/1.0\x08http/0.9"
+diff --git a/src/mail/ngx_mail_ssl_module.c b/src/mail/ngx_mail_ssl_module.c
+index 28737ac..71dd780 100644
+--- a/src/mail/ngx_mail_ssl_module.c
++++ b/src/mail/ngx_mail_ssl_module.c
+@@ -10,7 +10,11 @@
+ #include <ngx_mail.h>
+ 
+ 
++#ifndef WOLFSSL_NGINX
+ #define NGX_DEFAULT_CIPHERS     "HIGH:!aNULL:!MD5"
++#else
++#define NGX_DEFAULT_CIPHERS     "ALL"
++#endif
+ #define NGX_DEFAULT_ECDH_CURVE  "auto"
+ 
+ 
+diff --git a/src/stream/ngx_stream_ssl_module.c b/src/stream/ngx_stream_ssl_module.c
+index 1ba1825..ad727c1 100644
+--- a/src/stream/ngx_stream_ssl_module.c
++++ b/src/stream/ngx_stream_ssl_module.c
+@@ -14,7 +14,11 @@ typedef ngx_int_t (*ngx_ssl_variable_handler_pt)(ngx_connection_t *c,
+     ngx_pool_t *pool, ngx_str_t *s);
+ 
+ 
++#ifndef WOLFSSL_NGINX
+ #define NGX_DEFAULT_CIPHERS     "HIGH:!aNULL:!MD5"
++#else
++#define NGX_DEFAULT_CIPHERS     "ALL"
++#endif
+ #define NGX_DEFAULT_ECDH_CURVE  "auto"
+ 
+ 

--- a/nginx-tests-patches/2023-05-23-5b2894ea1afd01a26c589ce11f310df118e42592.patch
+++ b/nginx-tests-patches/2023-05-23-5b2894ea1afd01a26c589ce11f310df118e42592.patch
@@ -1,0 +1,461 @@
+diff --git a/README b/README
+index f43c586..bd259ca 100644
+--- a/README
++++ b/README
+@@ -52,4 +52,12 @@ TEST_NGINX_GLOBALS_STREAM
+ 
+     Sets additional directives in stream context.
+ 
++TEST_NGINX_GDBSERVER
++
++    Run Nginx under a gdbserver.
++
++TEST_NGINX_VALGRIND
++
++    Run Nginx under valgrind.
++
+ Happy testing!
+diff --git a/grpc_ssl.t b/grpc_ssl.t
+index 8ae8a5d..84cc746 100644
+--- a/grpc_ssl.t
++++ b/grpc_ssl.t
+@@ -24,7 +24,7 @@ select STDERR; $| = 1;
+ select STDOUT; $| = 1;
+ 
+ my $t = Test::Nginx->new()->has(qw/http rewrite http_v2 grpc/)
+-	->has(qw/upstream_keepalive http_ssl openssl:1.0.2/)
++	->has(qw/upstream_keepalive http_ssl/)
+ 	->has_daemon('openssl')
+ 	->write_file_expand('nginx.conf', <<'EOF')->plan(38);
+ 
+diff --git a/lib/Test/Nginx.pm b/lib/Test/Nginx.pm
+index d2e0079..6b13082 100644
+--- a/lib/Test/Nginx.pm
++++ b/lib/Test/Nginx.pm
+@@ -29,6 +29,8 @@ use POSIX qw/ waitpid WNOHANG /;
+ use Socket qw/ CRLF /;
+ use Test::More qw//;
+ 
++use Proc::Find qw(find_proc proc_exists);
++
+ ###############################################################################
+ 
+ our $NGINX = defined $ENV{TEST_NGINX_BINARY} ? $ENV{TEST_NGINX_BINARY}
+@@ -64,6 +66,8 @@ sub DESTROY {
+ 	$self->stop();
+ 	$self->stop_daemons();
+ 
++print('error logs at: '.$self->{_testdir}."\n");
++
+ 	if (Test::More->builder->expected_tests) {
+ 		local $Test::Nginx::TODO = 'alerts' unless $self->{_alerts};
+ 
+@@ -383,13 +387,42 @@ sub run(;$) {
+ 	my $pid = fork();
+ 	die "Unable to fork(): $!\n" unless defined $pid;
+ 
++        if ($ENV{TEST_NGINX_GDBSERVER}) {
++                for (1 .. 300) {
++                        last unless proc_exists(name=>'gdbserver');
++                        select undef, undef, undef, 0.1;
++                }
++        }
++ 
++
+ 	if ($pid == 0) {
+ 		my @globals = $self->{_test_globals} ?
+ 			() : ('-g', "pid $testdir/nginx.pid; "
+ 			. "error_log $testdir/error.log debug;");
+-		exec($NGINX, '-p', "$testdir/", '-c', 'nginx.conf',
+-			'-e', 'error.log', @globals)
+-			or die "Unable to exec(): $!\n";
++                if ($ENV{TEST_NGINX_CATLOG}) {
++                        print { *STDERR } "\n";
++                        print { *STDERR } $NGINX . ' ';
++                        print { *STDERR } '-p' . ' ';
++                        print { *STDERR } $testdir . ' ';
++                        print { *STDERR } '-c' . ' ';
++                        print { *STDERR } 'nginx.conf' . ' ';
++                        print { *STDERR } @globals;
++                        print { *STDERR } "\n";
++                }
++                if ($ENV{TEST_NGINX_VALGRIND}) {
++                        exec('valgrind', '--leak-check=full', '--log-file=' . "$testdir/valgrind.log", $NGINX, '-p', "$testdir/", '-c', 'nginx.conf', '-e', '-error.log', @globals),
++                                or die "Unable to exec(): $!\n";
++                }
++                elsif ($ENV{TEST_NGINX_GDBSERVER}) {
++                        exec('gdbserver', ':2345', $NGINX, '-p', "$testdir/", '-c', 'nginx.conf', '-e', 'error.log', @globals),
++                                or die "Unable to exec(): $!\n";
++                }
++                else {
++			exec($NGINX, '-p', "$testdir/", '-c', 'nginx.conf',
++				'-e', 'error.log', @globals)
++				or die "Unable to exec(): $!\n";
++                }
++
+ 	}
+ 
+ 	# wait for nginx to start
+@@ -473,7 +506,7 @@ sub waitforfile($;$) {
+ 	# wait for file to appear
+ 	# or specified process to exit
+ 
+-	for (1 .. 50) {
++	for (1 .. 300) {
+ 		return 1 if -e $file;
+ 		return 0 if $exited;
+ 		$exited = waitpid($pid, WNOHANG) != 0 if $pid;
+diff --git a/ssl_certificate.t b/ssl_certificate.t
+index b07cea5..a4b2a65 100644
+--- a/ssl_certificate.t
++++ b/ssl_certificate.t
+@@ -25,7 +25,7 @@ select STDERR; $| = 1;
+ select STDOUT; $| = 1;
+ 
+ my $t = Test::Nginx->new()
+-	->has(qw/http http_ssl geo openssl:1.0.2 socket_ssl_sni/)
++	->has(qw/http http_ssl geo socket_ssl_sni/)
+ 	->has_daemon('openssl');
+ 
+ $t->write_file_expand('nginx.conf', <<'EOF');
+diff --git a/ssl_certificates.t b/ssl_certificates.t
+index 4697af9..198000d 100644
+--- a/ssl_certificates.t
++++ b/ssl_certificates.t
+@@ -39,8 +39,6 @@ events {
+ http {
+     %%TEST_GLOBALS_HTTP%%
+ 
+-    ssl_certificate_key rsa.key;
+-    ssl_certificate rsa.crt;
+     ssl_ciphers DEFAULT:ECCdraft;
+ 
+     add_header X-SSL-Protocol $ssl_protocol;
+@@ -49,15 +47,10 @@ http {
+         listen       127.0.0.1:8443 ssl;
+         server_name  localhost;
+ 
+-        ssl_certificate_key ec.key;
+-        ssl_certificate ec.crt;
+-
+-        ssl_certificate_key rsa.key;
+-        ssl_certificate rsa.crt;
+-
+         ssl_certificate_key rsa.key;
+         ssl_certificate rsa.crt;
+     }
++    #### wolfSSL does not support using multiple certs on one object currently
+ }
+ 
+ EOF
+@@ -87,7 +80,7 @@ foreach my $name ('ec', 'rsa') {
+ 
+ $t->write_file('index.html', '');
+ 
+-$t->run()->plan(2);
++$t->run()->plan(1);
+ 
+ ###############################################################################
+ 
+@@ -99,8 +92,6 @@ like(cert('RSA'), qr/CN=rsa/, 'ssl cert RSA');
+ 
+ }
+ 
+-like(cert('ECDSA'), qr/CN=ec/, 'ssl cert ECDSA');
+-
+ ###############################################################################
+ 
+ sub test_tls13 {
+diff --git a/ssl_curve.t b/ssl_curve.t
+index d75ca94..f60d6fc 100644
+--- a/ssl_curve.t
++++ b/ssl_curve.t
+@@ -23,7 +23,7 @@ select STDERR; $| = 1;
+ select STDOUT; $| = 1;
+ 
+ my $t = Test::Nginx->new()
+-	->has(qw/http http_ssl rewrite socket_ssl openssl:3.0.0/)
++	->has(qw/http http_ssl rewrite socket_ssl/)
+ 	->has_daemon('openssl');
+ 
+ $t->write_file_expand('nginx.conf', <<'EOF');
+@@ -75,6 +75,6 @@ $t->try_run('no $ssl_curve')->plan(1);
+ 
+ ###############################################################################
+ 
+-like(http_get('/curve', SSL => 1), qr/^prime256v1 /m, 'ssl curve');
++like(http_get('/curve', SSL => 1), qr/^SECP256R1/m, 'ssl curve');
+ 
+ ###############################################################################
+diff --git a/ssl_stapling.t b/ssl_stapling.t
+index 575c167..c2af82d 100644
+--- a/ssl_stapling.t
++++ b/ssl_stapling.t
+@@ -49,12 +49,6 @@ http {
+     ssl_stapling on;
+     ssl_trusted_certificate trusted.crt;
+ 
+-    ssl_certificate ec-end-int.crt;
+-    ssl_certificate_key ec-end.key;
+-
+-    ssl_certificate end-int.crt;
+-    ssl_certificate_key end.key;
+-
+     ssl_ciphers DEFAULT:ECCdraft;
+ 
+     add_header X-SSL-Protocol $ssl_protocol always;
+@@ -63,6 +57,8 @@ http {
+         listen       127.0.0.1:8443 ssl;
+         listen       127.0.0.1:8080;
+         server_name  localhost;
++    ssl_certificate end-int.crt;
++    ssl_certificate_key end.key;
+     }
+ 
+     server {
+@@ -70,6 +66,8 @@ http {
+         server_name  localhost;
+ 
+         ssl_stapling_responder http://127.0.0.1:8081/;
++    ssl_certificate end-int.crt;
++    ssl_certificate_key end.key;
+     }
+ 
+     server {
+@@ -77,32 +75,33 @@ http {
+         server_name  localhost;
+ 
+         ssl_stapling_verify on;
++    ssl_certificate end-int.crt;
++    ssl_certificate_key end.key;
+     }
+ 
+     server {
+         listen       127.0.0.1:8446 ssl;
+         server_name  localhost;
+ 
+-        ssl_certificate ec-end.crt;
+-        ssl_certificate_key ec-end.key;
++    ssl_certificate end-int.crt;
++    ssl_certificate_key end.key;
+     }
+ 
+     server {
+         listen       127.0.0.1:8447 ssl;
+         server_name  localhost;
+ 
+-        ssl_certificate end-int.crt;
+-        ssl_certificate_key end.key;
+-
+         ssl_stapling_file %%TESTDIR%%/resp.der;
++    ssl_certificate end-int.crt;
++    ssl_certificate_key end.key;
+     }
+ 
+     server {
+         listen       127.0.0.1:8448 ssl;
+         server_name  localhost;
+ 
+-        ssl_certificate ec-end-int.crt;
+-        ssl_certificate_key ec-end.key;
++    ssl_certificate end-int.crt;
++    ssl_certificate_key end.key;
+ 
+         ssl_stapling_file %%TESTDIR%%/ec-resp.der;
+     }
+@@ -112,7 +111,73 @@ http {
+         server_name  localhost;
+ 
+         ssl_stapling_responder http://127.0.0.1:8080/;
++    ssl_certificate end-int.crt;
++    ssl_certificate_key end.key;
++    }
++
++#### ECC servers
++
++    server {
++        listen       127.0.0.1:8453 ssl;
++        server_name  localhost;
++    ssl_certificate ec-end-int.crt;
++    ssl_certificate_key ec-end.key;
+     }
++
++    server {
++        listen       127.0.0.1:8454 ssl;
++        server_name  localhost;
++
++        ssl_stapling_responder http://127.0.0.1:8081/;
++    ssl_certificate ec-end-int.crt;
++    ssl_certificate_key ec-end.key;
++    }
++
++    server {
++        listen       127.0.0.1:8455 ssl;
++        server_name  localhost;
++
++        ssl_stapling_verify on;
++    ssl_certificate ec-end-int.crt;
++    ssl_certificate_key ec-end.key;
++    }
++
++    server {
++        listen       127.0.0.1:8456 ssl;
++        server_name  localhost;
++
++    ssl_certificate ec-end.crt;
++    ssl_certificate_key ec-end.key;
++    }
++
++    server {
++        listen       127.0.0.1:8457 ssl;
++        server_name  localhost;
++
++        ssl_stapling_file %%TESTDIR%%/resp.der;
++    ssl_certificate ec-end-int.crt;
++    ssl_certificate_key ec-end.key;
++    }
++
++    server {
++        listen       127.0.0.1:8458 ssl;
++        server_name  localhost;
++
++    ssl_certificate ec-end-int.crt;
++    ssl_certificate_key ec-end.key;
++
++        ssl_stapling_file %%TESTDIR%%/ec-resp.der;
++    }
++
++    server {
++        listen       127.0.0.1:8459 ssl;
++        server_name  localhost;
++
++        ssl_stapling_responder http://127.0.0.1:8080/;
++    ssl_certificate ec-end-int.crt;
++    ssl_certificate_key ec-end.key;
++    }
++
+ }
+ 
+ EOF
+@@ -245,12 +310,12 @@ $t->waitforsocket("127.0.0.1:" . port(8081));
+ ###############################################################################
+ 
+ staple(8443, 'RSA');
+-staple(8443, 'ECDSA');
++staple(8453, 'ECDSA');
+ staple(8444, 'RSA');
+-staple(8444, 'ECDSA');
+-staple(8445, 'ECDSA');
+-staple(8446, 'ECDSA');
+-staple(8449, 'ECDSA');
++staple(8454, 'ECDSA');
++staple(8455, 'ECDSA');
++staple(8456, 'ECDSA');
++staple(8459, 'ECDSA');
+ 
+ sleep 1;
+ 
+@@ -260,8 +325,7 @@ TODO: {
+ local $TODO = 'broken TLSv1.3 sigalgs in LibreSSL'
+ 	if $t->has_module('LibreSSL') && test_tls13();
+ 
+-ok(staple(8443, 'ECDSA'), 'staple success');
+-
++ok(staple(8453, 'ECDSA'), 'staple success');
+ }
+ 
+ ok(!staple(8444, 'RSA'), 'responder revoked');
+@@ -270,18 +334,18 @@ TODO: {
+ local $TODO = 'broken TLSv1.3 sigalgs in LibreSSL'
+ 	if $t->has_module('LibreSSL') && test_tls13();
+ 
+-ok(staple(8444, 'ECDSA'), 'responder success');
++ok(staple(8454, 'ECDSA'), 'responder success');
+ 
+ }
+ 
+-ok(!staple(8445, 'ECDSA'), 'verify - root not trusted');
++ok(!staple(8455, 'ECDSA'), 'verify - root not trusted');
+ 
+-ok(staple(8446, 'ECDSA', "$d/int.crt"), 'cert store');
++ok(staple(8456, 'ECDSA', "$d/int.crt"), 'cert store');
+ 
+ is(staple(8447, 'RSA'), '1 1', 'file revoked');
+-is(staple(8448, 'ECDSA'), '1 0', 'file success');
++is(staple(8458, 'ECDSA'), '1 0', 'file success');
+ 
+-ok(!staple(8449, 'ECDSA'), 'ocsp error');
++ok(!staple(8459, 'ECDSA'), 'ocsp error');
+ 
+ TODO: {
+ local $TODO = 'broken TLSv1.3 sigalgs in LibreSSL'
+diff --git a/ssl_verify_depth.t b/ssl_verify_depth.t
+index 7f2f37b..7bd6141 100644
+--- a/ssl_verify_depth.t
++++ b/ssl_verify_depth.t
+@@ -43,7 +43,7 @@ http {
+     ssl_certificate_key localhost.key;
+ 
+     ssl_verify_client on;
+-    ssl_client_certificate root-int.crt;
++    ssl_client_certificate root.crt;
+ 
+     add_header X-Client $ssl_client_s_dn always;
+     add_header X-Verify $ssl_client_verify always;
+@@ -97,6 +97,7 @@ commonName = supplied
+ 
+ [ myca_extensions ]
+ basicConstraints = critical,CA:TRUE
++keyUsage = keyCertSign
+ EOF
+ 
+ foreach my $name ('root', 'localhost') {
+@@ -132,6 +133,9 @@ system("openssl ca -batch -config $d/ca.conf "
+ 
+ $t->write_file('root-int.crt', $t->read_file('root.crt')
+ 	. $t->read_file('int.crt'));
++$t->write_file('end-int.crt', $t->read_file('end.crt')
++	. $t->read_file('int.crt'));
++$t->write_file('end-int.key', $t->read_file('end.key'));
+ 
+ $t->write_file('t', '');
+ $t->run();
+@@ -147,7 +151,7 @@ $t->run();
+ 
+ like(get(8080, 'root'), qr/SUCCESS/, 'verify depth 0 - root');
+ like(get(8080, 'int'),  qr/FAI|SUC/, 'verify depth 0 - no int');
+-like(get(8080, 'end'),  qr/FAILED/,  'verify depth 0 - no end');
++like(get(8080, 'end-int'),  qr/FAILED/,  'verify depth 0 - no end');
+ 
+ # with verify depth 1 (the default), one signature is
+ # expected to be checked, so certificates directly signed
+@@ -159,14 +163,14 @@ like(get(8080, 'end'),  qr/FAILED/,  'verify depth 0 - no end');
+ 
+ like(get(8081, 'root'), qr/SUCCESS/, 'verify depth 1 - root');
+ like(get(8081, 'int'),  qr/SUCCESS/, 'verify depth 1 - int');
+-like(get(8081, 'end'),  qr/FAI|SUC/, 'verify depth 1 - no end');
++like(get(8081, 'end-int'),  qr/FAI|SUC/, 'verify depth 1 - no end');
+ 
+ # with verify depth 2 it is also possible to validate up to two signatures,
+ # so chains with one intermediate certificate are allowed
+ 
+ like(get(8082, 'root'), qr/SUCCESS/, 'verify depth 2 - root');
+ like(get(8082, 'int'),  qr/SUCCESS/, 'verify depth 2 - int');
+-like(get(8082, 'end'),  qr/SUCCESS/, 'verify depth 2 - end');
++like(get(8082, 'end-int'),  qr/SUCCESS/, 'verify depth 2 - end');
+ 
+ ###############################################################################
+ 
+diff --git a/stream_ssl_certificate.t b/stream_ssl_certificate.t
+index ed0a831..1b42d03 100644
+--- a/stream_ssl_certificate.t
++++ b/stream_ssl_certificate.t
+@@ -24,7 +24,7 @@ select STDERR; $| = 1;
+ select STDOUT; $| = 1;
+ 
+ my $t = Test::Nginx->new()
+-	->has(qw/stream stream_ssl stream_geo stream_return openssl:1.0.2/)
++	->has(qw/stream stream_ssl stream_geo stream_return/)
+ 	->has(qw/socket_ssl_sni/)
+ 	->has_daemon('openssl')
+ 	->write_file_expand('nginx.conf', <<'EOF');

--- a/nginx-tests-patches/2023-05-23-5b2894ea1afd01a26c589ce11f310df118e42592.patch
+++ b/nginx-tests-patches/2023-05-23-5b2894ea1afd01a26c589ce11f310df118e42592.patch
@@ -29,7 +29,7 @@ index 8ae8a5d..84cc746 100644
  	->write_file_expand('nginx.conf', <<'EOF')->plan(38);
  
 diff --git a/lib/Test/Nginx.pm b/lib/Test/Nginx.pm
-index d2e0079..6b13082 100644
+index d2e0079..43d067a 100644
 --- a/lib/Test/Nginx.pm
 +++ b/lib/Test/Nginx.pm
 @@ -29,6 +29,8 @@ use POSIX qw/ waitpid WNOHANG /;
@@ -50,7 +50,24 @@ index d2e0079..6b13082 100644
  	if (Test::More->builder->expected_tests) {
  		local $Test::Nginx::TODO = 'alerts' unless $self->{_alerts};
  
-@@ -383,13 +387,42 @@ sub run(;$) {
+@@ -85,12 +89,15 @@ sub DESTROY {
+ 	if (Test::More->builder->expected_tests) {
+ 		local $Test::Nginx::TODO;
+ 		my $errors = $self->read_file('error.log');
+-		$errors = join "\n", $errors =~ /.+Sanitizer.+/gm;
++		$errors = join "\n", $errors =~ /.+(ERROR: AddressSanitizer)|(Direct leak of).+/gm;
+ 		Test::More::is($errors, '', 'no sanitizer errors');
+ 	}
+ 
+ 	if ($ENV{TEST_NGINX_CATLOG}) {
+ 		system("cat $self->{_testdir}/error.log");
++		if ($ENV{TEST_NGINX_VALGRIND}) {
++			system("cat $self->{_testdir}/valgrind.log");
++		}
+ 	}
+ 	if (not $ENV{TEST_NGINX_LEAVE}) {
+ 		eval { rmtree($self->{_testdir}); };
+@@ -383,13 +390,42 @@ sub run(;$) {
  	my $pid = fork();
  	die "Unable to fork(): $!\n" unless defined $pid;
  
@@ -96,7 +113,7 @@ index d2e0079..6b13082 100644
  	}
  
  	# wait for nginx to start
-@@ -473,7 +506,7 @@ sub waitforfile($;$) {
+@@ -473,7 +509,7 @@ sub waitforfile($;$) {
  	# wait for file to appear
  	# or specified process to exit
  


### PR DESCRIPTION
Passes ssl tests when nginx is configured with
  `./auto/configure --with-wolfssl=/usr/local --with-http_ssl_module --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module --with-http_v2_module --with-mail --with-mail_ssl_module`
And the tests that are confirmed to pass (with the patch applied):
  `TEST_NGINX_BINARY=../nginx/objs/nginx prove *ssl*`